### PR TITLE
adding functionality/testing for eh

### DIFF
--- a/lib/canada/exceptions.rb
+++ b/lib/canada/exceptions.rb
@@ -1,0 +1,8 @@
+
+module Canada
+  class NotFromAroundHereError < NoMethodError
+    def initialize(method, target)
+      super "I'm sorry, #{target} doesn't appear to have '#{method}' method accommodations, it must not be from around here"
+    end
+  end
+end

--- a/test/TimHortons.rb
+++ b/test/TimHortons.rb
@@ -1,0 +1,20 @@
+class TimHortons
+
+  def initialize
+    @doughnuts = Array.new
+  end
+
+  def bake(type)
+    @doughnuts << type
+  end
+
+  def doughnutAvailable?(search)
+    @doughnuts.include?(search)
+  end
+
+  # Define Canadianisms 
+  def eh_doughnutAvailable(type)
+    bake(type)
+  end
+
+end

--- a/test/canada_test.rb
+++ b/test/canada_test.rb
@@ -1,10 +1,21 @@
-require 'minitest_helper'
+require_relative 'minitest_helper'
+require 'TimHortons'
 require 'canada'
+require 'canada/exceptions'
 
 class CanadaTest < MiniTest::Test
   def test_eh?
     assert [].empty_eh?
     refute [1,2,3].empty_eh?
+  end
+
+  def test_eh!
+    timmies = TimHortons.new
+    refute timmies.doughnutAvailable_eh?("maple")
+    assert timmies.doughnutAvailable_eh!("maple")
+    assert_raises(Canada::NotFromAroundHereError) do 
+    	[].empty_eh!
+    end
   end
 
   def test_respond_to_eh?

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,3 +1,4 @@
 require 'minitest/autorun'
 
 $:.unshift File.expand_path("../../lib", __FILE__)
+$:.unshift File.expand_path("../../test", __FILE__)


### PR DESCRIPTION
Hello from Ottawa!  Sorry to bother you guys, but I was looking at your gem and after looking at issue #2, I realized that there were a couple of problems people had with the "eh?" functionality in the gem.  Luckily, ruby standards resolve one of those issues, so we can all be happy Canadians!

Ruby's naming conventions for mutation procedures is borrowed from scheme (section 1.3.5: http://www.schemers.org/Documents/Standards/R5RS/HTML/).  What they're describing is similar to what somebody was mentioning when they said that the "eh" method should seek to accommodate the user's request.  As such, I've created some extra functionality which implements an "eh!" method, for which Canadian made classes can seek said accommodations.

It would be expected of Canadian classes to include eh_{method name} methods for commonly used methods which could return undesired results.  This method should contain instructions for how to accommodate the calling object's request, even in a situation where the Canadian object would usually return something the object wouldn't want.  This abstracts needing to know all of the methods involved in making a commonly desired method return commonly desired results.

In the test example, we have a Tim Hortons (which I understand is a bit bigger here out east than it is in Vancouver, but let's be inclusive here) which doesn't have maple doughnuts ready.  Calling the "doughnutAvailable_eh!" method causes a batch of maple doughnuts to be baked, to accommodate the maple doughnut request.  

In the future, a more verbose example should be used where we should probably have more than just a "bake" method call in the eh_doughnutAvailable method in the Tim Hortons class - maybe a "glaze" method that takes a thickness int for the glaze, or a "fillDoughnut" method that takes a volume of maple cream to be piped into it.  That way, we can have extra instructions for how to make maple doughnuts which the requesting class no longer needs to know about.  After all, I don't know how to make maple doughnuts, but that shouldn't stop me from being able to ask for them to be made for me.

The changes also include an error for when "_eh!" is called on a non-Canadian class.  It will tell you that the class probably isn't from around here.

If any of you guys are even in Ottawa on a Tuesday night, check out http://ottawaruby.ca/ to see if we have an event going on!
