### PR TITLE
Having to say 'raise' to bring up an error message seems confrontational.

### DIFF
--- a/lib/canada.rb
+++ b/lib/canada.rb
@@ -47,5 +47,7 @@ module Canada
     def aboot(obj)
       obj.inspect
     end
+
+    alias :sorry :raise
   end
 end

--- a/test/canada_test.rb
+++ b/test/canada_test.rb
@@ -46,4 +46,10 @@ class CanadaTest < MiniTest::Test
     assert_match /(#{prefix}), (#{connector}) #{msg}/, Exception.new(msg).to_s
     assert_match /(#{prefix}), (#{connector}) #{msg}/, Exception.new(msg).message
   end
+
+  def test_sorry_raises
+    assert_raises Exception do
+      sorry Exception.new("Take off, eh")
+    end
+  end
 end


### PR DESCRIPTION
Alias 'sorry' to 'raise' to make this just a little more polite.