### PR TITLE
Make Ruby more polite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ It's well known that we have [different conventions](http://programmers.stackexc
 => false
 >> [].respond_to_eh?(:empty_eh?)
 => true
+>> str = 'You Hoser'
+>> str.upcase_please
+>> str
+=> 'YOU HOSER'
 >> aboot Object.new
 => "#<Object:0x007f802b8b92c0>"
 >> raise "something went wrong..."

--- a/lib/canada.rb
+++ b/lib/canada.rb
@@ -3,10 +3,13 @@ require "canada/version"
 module Canada
   module ObjectExtensions
     EH_METHOD_REGEXP = /\A(?<method_name>.+)_eh\?\z/
+    PLEASE_METHOD_REGEXP = /\A(?<method_name>.+)_please\z/
 
     def respond_to_missing?(meth, include_all = false)
       if (m = EH_METHOD_REGEXP.match(meth))
         super || self.respond_to?("#{m[:method_name]}?", include_all)
+      elsif (m = PLEASE_METHOD_REGEXP.match(meth))
+        super || self.respond_to?("#{m[:method_name]}!", include_all)
       else
         super
       end
@@ -15,6 +18,8 @@ module Canada
     def method_missing(meth, *args, &block)
       if (m = EH_METHOD_REGEXP.match(meth))
         self.public_send("#{m[:method_name]}?", *args, &block)
+      elsif (m = PLEASE_METHOD_REGEXP.match(meth))
+        self.public_send("#{m[:method_name]}!", *args, &block)
       else
         super
       end

--- a/test/canada_test.rb
+++ b/test/canada_test.rb
@@ -23,6 +23,26 @@ class CanadaTest < MiniTest::Test
     no.each { |n| refute([].respond_to?(n), "Array should not respond_to_eh? #{n}") }
   end
 
+  def test_please
+    expectations = {
+      capitalize_please: ['good day', "Good day"],
+      chomp_please: ["Good Day\n", 'Good Day'],
+      chop_please: ['Good Day!', 'Good Day'],
+      downcase_please: ['Good Day', 'good day'],
+      lstrip_please: [' Good Day', 'Good Day'],
+      reverse_please: ['Good Day', 'yaD dooG'],
+      rstrip_please: ['Good Day ', 'Good Day'],
+      succ_please: ['Good Day', 'Good Daz'],
+      upcase_please: ['Good Day', 'GOOD DAY']
+    }
+
+    expectations.each do |m, (before, after)|
+      before.send m
+      assert(before == after, "String##{m} should equal #{after}")
+      assert(before.respond_to?(m), "String should respond_to? #{m}")
+    end
+  end
+
   def test_aboot
     cases = [
       [],


### PR DESCRIPTION
Bang methods are just so pushy but everybody knows Canadians are nice. Wouldn't it be better if we could just say `String#upcase_please` or `User#save_please`?